### PR TITLE
Add option button labels

### DIFF
--- a/pose-babylon/index.html
+++ b/pose-babylon/index.html
@@ -61,17 +61,39 @@
     <div id="options-menu" class="options-menu hidden">
         <button id="options-close" class="option-btn close-btn">X</button>
         <div class="option-row">
-            <button id="orientation" class="orientation option-btn"></button>
-            <span id="orientation-label" class="option-label">ON</span>
+            <div class="option-item">
+                <span class="button-label">Orientation</span>
+                <button id="orientation" class="orientation option-btn"></button>
+                <span id="orientation-label" class="option-label">ON</span>
+            </div>
         </div>
         <div class="option-row">
-            <button id="calibrate" class="option-btn">Calibrate</button>
-            <button id="height-minus" class="option-btn small">-</button>
+            <div class="option-item">
+                <span class="button-label">Calibrate</span>
+                <button id="calibrate" class="option-btn">Calibrate</button>
+            </div>
+            <div class="option-item">
+                <span class="button-label">Height -</span>
+                <button id="height-minus" class="option-btn small">-</button>
+            </div>
             <span id="height-label" class="option-label">170 cm</span>
-            <button id="height-plus" class="option-btn small">+</button>
+            <div class="option-item">
+                <span class="button-label">Height +</span>
+                <button id="height-plus" class="option-btn small">+</button>
+            </div>
         </div>
-        <button id="switch-camera" class="option-btn">Switch Camera</button>
-        <button id="export-csv" class="option-btn">Export Smiles</button>
+        <div class="option-row">
+            <div class="option-item">
+                <span class="button-label">Switch Camera</span>
+                <button id="switch-camera" class="option-btn">Switch Camera</button>
+            </div>
+        </div>
+        <div class="option-row">
+            <div class="option-item">
+                <span class="button-label">Export Smiles</span>
+                <button id="export-csv" class="option-btn">Export Smiles</button>
+            </div>
+        </div>
     </div>
 
 

--- a/pose-babylon/src/index.css
+++ b/pose-babylon/src/index.css
@@ -141,6 +141,20 @@ body {
   gap: var(--gap);
 }
 
+/* stack label and button vertically */
+.option-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.button-label {
+  color: #fff;
+  font-size: var(--font-size);
+  text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+}
+
 .option-btn {
   width: var(--btn-size);
   height: var(--btn-size);


### PR DESCRIPTION
## Summary
- redesign option menu with labels stacked above each button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a0f2d5290832ba215414a97e08ebc