### PR TITLE
Improve calibration and measurement

### DIFF
--- a/pose-babylon/src/avatarrenderer.ts
+++ b/pose-babylon/src/avatarrenderer.ts
@@ -360,11 +360,14 @@ export class AvatarRenderer extends PoseRenderer {
         };
 
         try {
+            const stored = parseFloat(localStorage.getItem("cmPerPx") || "NaN");
+            const cmPerPxCalibrated = Number.isFinite(stored) ? stored : 1.70;
             const { measures, size } = await MeasurementService.measureAndSuggest(
                 simplePose,
                 this.gl,
                 stream.height,
-                stream.width
+                stream.width,
+                cmPerPxCalibrated
             );
 
             // 4) Atualizar UI

--- a/pose-babylon/src/index.ts
+++ b/pose-babylon/src/index.ts
@@ -22,6 +22,11 @@ let rear = urlParams.has("rear");
 let currentStream: MediaStream | null = null;
 let transpose = true;
 let userHeightCm = 170;
+let savedCmPerPx: number | null = (() => {
+  const v = localStorage.getItem("cmPerPx");
+  const num = v ? parseFloat(v) : NaN;
+  return Number.isFinite(num) ? num : null;
+})();
 
 let outfitModel = "polo";
 let hatModel = "dadA";
@@ -165,6 +170,20 @@ function bindCalibrate() {
     }
     const headYnorm = pose.points.nose.pixel[1] - 0.10;
     const ankleYnorm = Math.max(pose.points.ankleL.pixel[1], pose.points.ankleR.pixel[1]);
+    const xVals = [
+      pose.points.shoulderL.pixel[0],
+      pose.points.shoulderR.pixel[0],
+      pose.points.hipL.pixel[0],
+      pose.points.hipR.pixel[0],
+      pose.points.ankleL.pixel[0],
+      pose.points.ankleR.pixel[0]
+    ];
+    const minX = Math.min(...xVals);
+    const maxX = Math.max(...xVals);
+    if (headYnorm < 0 || ankleYnorm > 1 || minX < 0 || maxX > 1) {
+      alert('Certifique-se de que o corpo inteiro esteja visível.');
+      return;
+    }
     const canvasH = ui.video.videoHeight;
     const headYpx = headYnorm * canvasH;
     const ankleYpx = ankleYnorm * canvasH;
@@ -174,6 +193,8 @@ function bindCalibrate() {
       return;
     }
     const cmPerPx = userHeightCm / heightPx;
+    savedCmPerPx = cmPerPx;
+    localStorage.setItem('cmPerPx', cmPerPx.toString());
     const gl = (avatarRenderer as any).gl as WebGLRenderingContext;
     const { texture, size } = pose.maskTex;
     const maskW = size.width, maskH = size.height;

--- a/pose-babylon/src/measurementService.ts
+++ b/pose-babylon/src/measurementService.ts
@@ -260,13 +260,16 @@ export class MeasurementService {
    * @param pose – SimplePose (landmarks + maskTex obrigatório)
    * @param gl – contexto WebGL para ler a textura
    * @param canvasHeight – altura do canvas visível (pixels)
+   * @param canvasWidth – largura do canvas (pixels)
+   * @param cmPerPx – fator de escala cm/px a ser usado nas medições
    * @returns BodyMeasurements + SizeLabel
    */
   static async measureAndSuggest(
     pose: SimplePose,
     gl: WebGLRenderingContext,
     canvasHeight: number,
-    canvasWidth: number
+    canvasWidth: number,
+    cmPerPx: number
   ): Promise<{ measures: BodyMeasurements; size: SizeLabel }> {
     // 7.1) Verificar se há máscara
     if (!pose.maskTex) {
@@ -294,8 +297,7 @@ export class MeasurementService {
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     gl.deleteFramebuffer(framebuffer);
 
-    // 7.3) Calcular cmPerPx (usar ombros)
-    const cmPerPx = this.computeScaleCmPerPx(pose, canvasWidth, canvasHeight);
+    // 7.3) Usar o cmPerPx informado (calibrado ou padrão)
 
     // 7.4) Medir largura de peito e cintura em cm
     const chestCm = this.measureWidthCm(


### PR DESCRIPTION
## Summary
- ensure calibration checks full body visibility
- persist cmPerPx in local storage and reuse in measurement service
- allow measurement service to use saved scaling factor

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a1758dc28832ba4da26b60a298535