### PR TITLE
Add simple loading animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Key components:
 * **Calibration Module**: button to input user height for pixel‑to‑cm conversion.
 * **Carousel Selectors**: choose among multiple outfits, hats, and backgrounds.
 
-* **Options Menu**: toggle actions like calibration, camera switching and smile export.
+* **Options Menu**: toggle actions like calibration, camera switching and smile export. Also adjust the delay before the holding screen reappears when no pose is detected.
 
 * **Size Estimation Display**: shows calculated clothing size in real time.
 

--- a/pose-babylon/index.html
+++ b/pose-babylon/index.html
@@ -15,7 +15,7 @@
 
     <div id="loading-screen" class="full-screen loading-screen">
         <img class="loading-logo" src="./UI/MC_logo_1_2.png" alt="Scan icon" />
-        <div class="loading-text">Loading...</div>
+        <div id="loading-text" class="loading-text">Loading</div>
     </div>
 
     <video id="video" autoplay muted playsinline style="display: none;"></video>
@@ -72,6 +72,18 @@
             <div class="option-item">
                 <span class="button-label">Export Smiles</span>
                 <button id="export-csv" class="option-btn">Export Smiles</button>
+            </div>
+        </div>
+        <div class="option-row">
+            <div class="option-item">
+                <span class="button-label">Music</span>
+                <button id="music-toggle" class="option-btn">Toggle Music</button>
+            </div>
+        </div>
+        <div class="option-row">
+            <div class="option-item">
+                <span class="button-label">No Pose Delay (s)</span>
+                <input id="no-pose-delay" class="option-input" type="number" min="1" value="5" />
             </div>
         </div>
     </div>

--- a/pose-babylon/src/index.css
+++ b/pose-babylon/src/index.css
@@ -81,6 +81,21 @@ body {
   z-index: 200001; /* above all other elements */
 }
 
+.loading-text::after {
+  content: '...';
+  overflow: hidden;
+  display: inline-block;
+  vertical-align: bottom;
+  width: 0;
+  animation: dots 1s steps(4, end) infinite;
+}
+
+@keyframes dots {
+  to {
+    width: 1.5em;
+  }
+}
+
 .top-icon {
   position: fixed;      /* fix to viewport */
   top: 13rem;            /* distance from top of screen */
@@ -177,6 +192,16 @@ body {
   font-size: var(--font-size);
   text-shadow: 0 1px 3px rgba(0,0,0,0.6);
   white-space: nowrap;
+}
+
+.option-input {
+  width: 4rem;
+  padding: 0.25rem;
+  font-size: var(--font-size);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.1);
+  color: #fff;
 }
 
 /* bigger “×” in corner of panel */

--- a/pose-babylon/src/index.ts
+++ b/pose-babylon/src/index.ts
@@ -139,6 +139,24 @@ function bindOptionsClose() {
   ui.optionsClose.onclick = () => ui.toggleOptions();
 }
 
+function bindMusicToggle() {
+  ui.musicToggle.onclick = () => {
+    audioManager.playClickSfx();
+    audioManager.toggleMute();
+  };
+}
+
+function bindNoPoseDelay() {
+  ui.noPoseDelayInput.onchange = () => {
+    const sec = parseFloat(ui.noPoseDelayInput.value);
+    if (!isNaN(sec) && sec > 0) {
+      avatarRenderer.noPoseDelay = sec * 1000;
+    }
+  };
+  // set initial value from renderer
+  ui.noPoseDelayInput.value = String(avatarRenderer.noPoseDelay / 1000);
+}
+
 
 async function main() {
 
@@ -152,6 +170,8 @@ async function main() {
   bindTransposeButton();
   bindOptionsToggle();
   bindOptionsClose();
+  bindMusicToggle();
+  bindNoPoseDelay();
   bindExportButton();
   bindCarousel(
     ui.outfitButtons,

--- a/pose-babylon/src/uiController.ts
+++ b/pose-babylon/src/uiController.ts
@@ -12,6 +12,8 @@ export class UIController {
     public scannerFrame: HTMLElement;
     //public recordButton: HTMLButtonElement;
     public exportButton: HTMLButtonElement;
+    public musicToggle: HTMLButtonElement;
+    public noPoseDelayInput: HTMLInputElement;
     public optionsToggle: HTMLButtonElement;
     public optionsMenu: HTMLElement;
     public optionsClose: HTMLButtonElement;
@@ -59,6 +61,8 @@ export class UIController {
         const transposeBtn = document.getElementById("orientation");
         //const recordBtn = document.getElementById("record");
         const exportBtn = document.getElementById("export-csv");
+        const musicToggle = document.getElementById("music-toggle");
+        const noPoseDelayInput = document.getElementById("no-pose-delay");
         const optionsToggle = document.getElementById("options-toggle");
         const optionsMenu = document.getElementById("options-menu");
         const orientationLabel = document.getElementById("orientation-label");
@@ -72,7 +76,7 @@ export class UIController {
         const scanEl = document.getElementById('scanner-overlay');
         const scanFrameEl = document.getElementById('scanner-frame');
         // Validate mandatory elements
-        if (!scanFrameEl || !scanEl || !bgi || !hs || !sb || !videoEl || !faceCanvasEl || !containerEl || !transposeBtn || !exportBtn || !welcomeEl || !optionsToggle || !optionsMenu || !orientationLabel || !optionsClose) {
+        if (!scanFrameEl || !scanEl || !bgi || !hs || !sb || !videoEl || !faceCanvasEl || !containerEl || !transposeBtn || !exportBtn || !musicToggle || !noPoseDelayInput || !welcomeEl || !optionsToggle || !optionsMenu || !orientationLabel || !optionsClose) {
 
             throw new Error("Missing one or more UI elements in DOM");
         }
@@ -84,6 +88,8 @@ export class UIController {
         if (!(exportBtn instanceof HTMLButtonElement)) throw new Error("#export-csv is not a HTMLButtonElement");
         if (!(optionsToggle instanceof HTMLButtonElement)) throw new Error("#options-toggle is not a HTMLButtonElement");
         if (!(optionsClose instanceof HTMLButtonElement)) throw new Error("#options-close is not a HTMLButtonElement");
+        if (!(musicToggle instanceof HTMLButtonElement)) throw new Error("#music-toggle is not a HTMLButtonElement");
+        if (!(noPoseDelayInput instanceof HTMLInputElement)) throw new Error("#no-pose-delay is not an HTMLInputElement");
 
         // Assign references
         this.backgroundImg = bgi;
@@ -96,6 +102,8 @@ export class UIController {
         this.transposeButton = transposeBtn as HTMLButtonElement;
         //this.recordButton        = recordBtn as HTMLButtonElement;
         this.exportButton = exportBtn as HTMLButtonElement;
+        this.musicToggle = musicToggle as HTMLButtonElement;
+        this.noPoseDelayInput = noPoseDelayInput as HTMLInputElement;
         this.optionsToggle = optionsToggle as HTMLButtonElement;
         this.optionsMenu = optionsMenu as HTMLElement;
         this.orientationLabel = orientationLabel as HTMLElement;


### PR DESCRIPTION
## Summary
- add `id="loading-text"` and move `...` to CSS animation
- animate loading screen text with keyframed dots
- timer for no-pose detection now works in seconds
- option menu lets user specify delay before holding screen returns

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b89c921bc832ba4346f7d9cc0c182