### PR TITLE
Style options menu with grid layout and switches

### DIFF
--- a/pose-babylon/index.html
+++ b/pose-babylon/index.html
@@ -61,29 +61,30 @@
     <div id="options-menu" class="options-menu hidden">
         <button id="options-close" class="option-btn close-btn">X</button>
         <div class="option-row">
-            <div class="option-item">
-                <span class="button-label">Orientation</span>
-                <button id="orientation" class="orientation option-btn"></button>
+            <span class="option-label">Orientation</span>
+            <div class="option-control">
+                <input id="orientation" type="checkbox" class="toggle-switch" />
                 <span id="orientation-label" class="option-label">Vertical</span>
             </div>
         </div>
         
         <div class="option-row">
-            <div class="option-item">
-                <span class="button-label">Export Smiles</span>
+            <span class="option-label">Export Smiles</span>
+            <div class="option-control">
                 <button id="export-csv" class="option-btn">Export Smiles</button>
             </div>
         </div>
         <div class="option-row">
-            <div class="option-item">
-                <span class="button-label">Music</span>
-                <button id="music-toggle" class="option-btn">Toggle Music</button>
+            <span class="option-label">Music</span>
+            <div class="option-control">
+                <input id="music-toggle" type="checkbox" class="toggle-switch" />
             </div>
         </div>
         <div class="option-row">
-            <div class="option-item">
-                <span class="button-label">No Pose Delay (s)</span>
-                <input id="no-pose-delay" class="option-input" type="number" min="1" value="5" />
+            <span class="option-label">No Pose Delay</span>
+            <div class="option-control">
+                <input id="no-pose-delay" class="option-input" type="range" min="1" max="10" value="5" />
+                <span id="no-pose-delay-value" class="option-label">5</span>
             </div>
         </div>
     </div>

--- a/pose-babylon/src/index.css
+++ b/pose-babylon/src/index.css
@@ -137,8 +137,8 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
   width: var(--menu-width);
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr auto;
   gap: var(--gap);
   background: var(--bg);
   backdrop-filter: blur(8px);
@@ -147,13 +147,12 @@ body {
   border: 1px solid var(--border);
   box-shadow: 0 6px 20px rgba(0 0 0 / 0.25);
   z-index: 10000;
+  align-items: center;
 }
 
 /* each line: big icon + text */
 .option-row {
-  display: flex;
-  align-items: center;
-  gap: var(--gap);
+  display: contents;
 }
 
 /* stack label and button vertically */
@@ -192,6 +191,7 @@ body {
   font-size: var(--font-size);
   text-shadow: 0 1px 3px rgba(0,0,0,0.6);
   white-space: nowrap;
+  text-align: left;
 }
 
 .option-input {
@@ -202,6 +202,44 @@ body {
   border: 1px solid var(--border);
   background: rgba(255,255,255,0.1);
   color: #fff;
+}
+
+.option-control {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toggle-switch {
+  appearance: none;
+  width: 3rem;
+  height: 1.5rem;
+  background: rgba(255,255,255,0.3);
+  border-radius: 1rem;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+}
+
+.toggle-switch::before {
+  content: "";
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle-switch:checked {
+  background: rgba(0,0,0,0.6);
+}
+
+.toggle-switch:checked::before {
+  transform: translateX(1.5rem);
 }
 
 /* bigger “×” in corner of panel */
@@ -246,8 +284,8 @@ body {
   left: 50%;
   transform: translate(-50%, -50%);
   width: var(--menu-width);
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr auto;
   gap: var(--gap);
   background: var(--bg);
   backdrop-filter: blur(8px);
@@ -256,13 +294,12 @@ body {
   border: 1px solid var(--border);
   box-shadow: 0 6px 20px rgba(0 0 0 / 0.25);
   z-index: 10000;
+  align-items: center;
 }
 
 /* each line: big icon + text */
 .option-row {
-  display: flex;
-  align-items: center;
-  gap: var(--gap);
+  display: contents;
 }
 
 .option-btn {
@@ -287,6 +324,7 @@ body {
   font-size: var(--font-size);
   text-shadow: 0 1px 3px rgba(0,0,0,0.6);
   white-space: nowrap;
+  text-align: left;
 }
 
 /* bigger “×” in corner of panel */

--- a/pose-babylon/src/index.ts
+++ b/pose-babylon/src/index.ts
@@ -96,7 +96,7 @@ function bindStartButton() {
 }
 
 function bindTransposeButton() {
-  (ui.transposeButton as HTMLButtonElement).onclick = async () => {
+  (ui.transposeButton as HTMLInputElement).onclick = async () => {
     transpose = !transpose;
     audioManager.playClickSfx();
     avatarRenderer.setMirror(!transpose);
@@ -151,10 +151,12 @@ function bindNoPoseDelay() {
     const sec = parseFloat(ui.noPoseDelayInput.value);
     if (!isNaN(sec) && sec > 0) {
       avatarRenderer.noPoseDelay = sec * 1000;
+      ui.noPoseDelayValue.textContent = String(sec);
     }
   };
   // set initial value from renderer
   ui.noPoseDelayInput.value = String(avatarRenderer.noPoseDelay / 1000);
+  ui.noPoseDelayValue.textContent = ui.noPoseDelayInput.value;
 }
 
 

--- a/pose-babylon/src/uiController.ts
+++ b/pose-babylon/src/uiController.ts
@@ -7,13 +7,14 @@ export class UIController {
     public faceCanvas: HTMLCanvasElement;
     public faceCtx: CanvasRenderingContext2D;
     public container: HTMLElement;
-    public transposeButton: HTMLButtonElement;
+    public transposeButton: HTMLInputElement;
     public scanner: HTMLElement;
     public scannerFrame: HTMLElement;
     //public recordButton: HTMLButtonElement;
     public exportButton: HTMLButtonElement;
-    public musicToggle: HTMLButtonElement;
+    public musicToggle: HTMLInputElement;
     public noPoseDelayInput: HTMLInputElement;
+    public noPoseDelayValue: HTMLElement;
     public optionsToggle: HTMLButtonElement;
     public optionsMenu: HTMLElement;
     public optionsClose: HTMLButtonElement;
@@ -63,6 +64,7 @@ export class UIController {
         const exportBtn = document.getElementById("export-csv");
         const musicToggle = document.getElementById("music-toggle");
         const noPoseDelayInput = document.getElementById("no-pose-delay");
+        const noPoseDelayValue = document.getElementById("no-pose-delay-value");
         const optionsToggle = document.getElementById("options-toggle");
         const optionsMenu = document.getElementById("options-menu");
         const orientationLabel = document.getElementById("orientation-label");
@@ -76,19 +78,19 @@ export class UIController {
         const scanEl = document.getElementById('scanner-overlay');
         const scanFrameEl = document.getElementById('scanner-frame');
         // Validate mandatory elements
-        if (!scanFrameEl || !scanEl || !bgi || !hs || !sb || !videoEl || !faceCanvasEl || !containerEl || !transposeBtn || !exportBtn || !musicToggle || !noPoseDelayInput || !welcomeEl || !optionsToggle || !optionsMenu || !orientationLabel || !optionsClose) {
+        if (!scanFrameEl || !scanEl || !bgi || !hs || !sb || !videoEl || !faceCanvasEl || !containerEl || !transposeBtn || !exportBtn || !musicToggle || !noPoseDelayInput || !noPoseDelayValue || !welcomeEl || !optionsToggle || !optionsMenu || !orientationLabel || !optionsClose) {
 
             throw new Error("Missing one or more UI elements in DOM");
         }
         // Type checks
         if (!(videoEl instanceof HTMLVideoElement)) throw new Error("#video is not a HTMLVideoElement");
         if (!(faceCanvasEl instanceof HTMLCanvasElement)) throw new Error("#faceCanvas is not a HTMLCanvasElement");
-        if (!(transposeBtn instanceof HTMLButtonElement)) throw new Error("#orientation is not a HTMLButtonElement");
+        if (!(transposeBtn instanceof HTMLInputElement)) throw new Error("#orientation is not an HTMLInputElement");
         //if (!(recordBtn instanceof HTMLButtonElement)) throw new Error("#record is not a HTMLButtonElement");
         if (!(exportBtn instanceof HTMLButtonElement)) throw new Error("#export-csv is not a HTMLButtonElement");
         if (!(optionsToggle instanceof HTMLButtonElement)) throw new Error("#options-toggle is not a HTMLButtonElement");
         if (!(optionsClose instanceof HTMLButtonElement)) throw new Error("#options-close is not a HTMLButtonElement");
-        if (!(musicToggle instanceof HTMLButtonElement)) throw new Error("#music-toggle is not a HTMLButtonElement");
+        if (!(musicToggle instanceof HTMLInputElement)) throw new Error("#music-toggle is not an HTMLInputElement");
         if (!(noPoseDelayInput instanceof HTMLInputElement)) throw new Error("#no-pose-delay is not an HTMLInputElement");
 
         // Assign references
@@ -99,11 +101,12 @@ export class UIController {
         this.faceCanvas = faceCanvasEl;
         this.faceCtx = faceCanvasEl.getContext("2d")!;
         this.container = containerEl;
-        this.transposeButton = transposeBtn as HTMLButtonElement;
+        this.transposeButton = transposeBtn as HTMLInputElement;
         //this.recordButton        = recordBtn as HTMLButtonElement;
         this.exportButton = exportBtn as HTMLButtonElement;
-        this.musicToggle = musicToggle as HTMLButtonElement;
+        this.musicToggle = musicToggle as HTMLInputElement;
         this.noPoseDelayInput = noPoseDelayInput as HTMLInputElement;
+        this.noPoseDelayValue = noPoseDelayValue as HTMLElement;
         this.optionsToggle = optionsToggle as HTMLButtonElement;
         this.optionsMenu = optionsMenu as HTMLElement;
         this.orientationLabel = orientationLabel as HTMLElement;
@@ -258,6 +261,7 @@ export class UIController {
 
     public updateOrientationLabel(transpose: boolean) {
         this.orientationLabel.textContent = transpose ? 'Vertical' : 'Horizontal';
+        this.transposeButton.checked = transpose;
     }
     
     public updateCarouselTextures(buttons: NodeListOf<HTMLInputElement>) {


### PR DESCRIPTION
## Summary
- style options menu as a grid with labels and controls
- add toggle‐switch styling
- use checkboxes for orientation and music toggles
- display no pose delay as a range slider with value

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bba08f0a0832b8d19f119cecdf266